### PR TITLE
fix: Exclude Ansible pyspelling check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,9 @@ repos:
           - 'pre-commit'
         pass_filenames: false
         verbose: true
+        args:
+          - '--name'
+          - 'markdown'
 
   - repo: 'https://github.com/tcort/markdown-link-check.git'
     rev: 'v3.12.2'


### PR DESCRIPTION
Spellchecking takes too long for longer files to be feasible during pre-commit